### PR TITLE
Added all_rental tag and pay as you go challenge

### DIFF
--- a/Challenges.lua
+++ b/Challenges.lua
@@ -37,14 +37,6 @@ function Card:set_perishable(_perishable)
   end
 end
 
-function Card:set_rental(_rental)
-  self.ability.rental = _rental
-  if G.GAME.modifiers.all_rental then
-    self.ability.rental = true
-  end
-  self:set_cost()
-end
-
 local blind_debuff_hand_ref = Blind.debuff_hand
 function Blind:debuff_hand(cards, hand, handname, check)
   if G.GAME.modifiers.cm_force_hand then

--- a/Challenges.lua
+++ b/Challenges.lua
@@ -13,8 +13,10 @@ function ChallengeMod.addLocalization()
   G.localization.misc.challenge_names.c_mod_swapped_pockets_1 = "Swapped Pockets"
   G.localization.misc.challenge_names.c_mod_tarot_tycoon_1 = "Tarot Tycoon"
   G.localization.misc.challenge_names.c_mod_unfortunate_1 = "Unfortunate"
+  G.localization.misc.challenge_names.c_mod_payasyougo_1 = "Pay As You Go"
   --  Challenge Descriptions
   G.localization.misc.v_text.ch_c_all_perishable = { "All Jokers are {C:perishable}Perishable{}" }
+  G.localization.misc.v_text.ch_c_all_rental = { "All Jokers are {C:rental}Rentals{}"}
   G.localization.misc.v_text.ch_c_cm_force_hand = { "Only #1#{}s will score" }
   G.localization.misc.v_text.ch_c_cm_negative_interest = { "Money is lost from interest" }
   G.localization.misc.v_text.ch_c_cm_no_overscoring = { "Final blind score must be lower than #1#{}%" }
@@ -30,6 +32,14 @@ function Card:set_perishable(_perishable)
     self.ability.perishable = true
     self.ability.perish_tally = G.GAME.perishable_rounds
   end
+end
+
+function Card:set_rental(_rental)
+  self.ability.rental = _rental
+  if G.GAME.modifiers.all_rental then
+    self.ability.rental = true
+  end
+  self:set_cost()
 end
 
 local blind_debuff_hand_ref = Blind.debuff_hand

--- a/Challenges/pay_as_you_go.lua
+++ b/Challenges/pay_as_you_go.lua
@@ -1,0 +1,35 @@
+return {
+	name = "Pay As You Go",
+	id = "c_mod_payasyougo_1",
+	rules = {
+		custom = {
+			{ id = "all_rental" },
+			{
+				id = "cm_credit",
+				value = "theQial",
+			},
+		},
+		modifiers = {
+      { id = "dollars", value = 15 },
+      { id = "discards", value = 4 },
+    },
+	},
+  vouchers = {
+    { id = "v_seed_money" },
+    { id = "v_money_tree" },
+  },
+	jokers = { { 
+    id = "j_credit_card",
+    edition = "negative",
+    eternal = true,
+    rental = false,
+  } },
+	deck = {
+		type = "Challenge Deck",
+	},
+	restrictions = {
+		banned_cards = {},
+		banned_tags = {},
+		banned_other = {},
+	},
+}


### PR DESCRIPTION
I've added an all_rental tag which works similarly to the all_perishable tag.

I copied the code from the game's source and added an extra line that sets rental to true if the challenge mod mode has all_rental.

I also created a Pay As You Go challenge. In the spirit of Rent-A-Center, you have an eternal negative credit card. To make it less mean you start with seed money and Money Tree. So if you are able to build wealth you can get interest to spend. And going below zero wont stop you from being able to search a bit for an econ joker to help. You also start with 15 since you will be spending it quick.